### PR TITLE
Added a warning about autoclose being disabled

### DIFF
--- a/public/templates/views/settings.tmpl
+++ b/public/templates/views/settings.tmpl
@@ -193,6 +193,7 @@
           <div class="card">
             <div class="card-header">
               <h4 class="card-title">Auto-Close</h4>
+              <div class="alert alert-danger">This feature is currently disabled. Changing the settings below may not currently be fully functional</div>
             </div>
             <div class="card-body">
               <form onsubmit="updateAutoCloseSettings(); return false;">


### PR DESCRIPTION
This PR displays a warning on the settings page for Auto Close as it is currently disabled