### PR TITLE
Updated Blacklist.svelte

### DIFF
--- a/frontend/src/views/Blacklist.svelte
+++ b/frontend/src/views/Blacklist.svelte
@@ -72,32 +72,6 @@
               <table class="nice">
                 <thead>
                 <tr>
-                  <th class="full-width">Role</th>
-                  <th>Remove</th>
-                </tr>
-                </thead>
-                <tbody>
-                {#each data.roles as role}
-                  <tr>
-                    {#if role.name === ''}
-                      <td class="full-width">Unknown ({role.id})</td>
-                    {:else}
-                      <td class="full-width">{role.name}</td>
-                    {/if}
-
-                    <td>
-                      <Button type="button" danger icon="fas fa-trash-can" on:click={() => removeRoleBlacklist(role)}>
-                        Remove
-                      </Button>
-                    </td>
-                  </tr>
-                {/each}
-                </tbody>
-              </table>
-
-              <table class="nice">
-                <thead>
-                <tr>
                   <th class="full-width">User</th>
                   <th>Remove</th>
                 </tr>
@@ -113,6 +87,32 @@
 
                     <td>
                       <Button type="button" danger icon="fas fa-trash-can" on:click={() => removeUserBlacklist(user)}>
+                        Remove
+                      </Button>
+                    </td>
+                  </tr>
+                {/each}
+                </tbody>
+              </table>
+
+              <table class="nice">
+                <thead>
+                <tr>
+                  <th class="full-width">Role</th>
+                  <th>Remove</th>
+                </tr>
+                </thead>
+                <tbody>
+                {#each data.roles as role}
+                  <tr>
+                    {#if role.name === ''}
+                      <td class="full-width">Unknown ({role.id})</td>
+                    {:else}
+                      <td class="full-width">{role.name}</td>
+                    {/if}
+
+                    <td>
+                      <Button type="button" danger icon="fas fa-trash-can" on:click={() => removeRoleBlacklist(role)}>
                         Remove
                       </Button>
                     </td>


### PR DESCRIPTION
Moving blacklisted users above blacklisted roles - more common, and it'll match the order of the buttons.  Just flipped the order.
<img width="1434" alt="Screen Shot 2022-08-09 at 5 47 11 PM" src="https://user-images.githubusercontent.com/71395931/183786536-40fbab9a-e2e5-4788-890f-cac1a79ed9e1.png">
