### PR TITLE
Fix: Dashboard login loop

### DIFF
--- a/app/http/endpoints/root/callback.go
+++ b/app/http/endpoints/root/callback.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/TicketsBot/GoPanel/app"
 	"github.com/TicketsBot/GoPanel/app/http/session"
 	"github.com/TicketsBot/GoPanel/config"
@@ -12,10 +17,6 @@ import (
 	"github.com/golang-jwt/jwt"
 	"github.com/rxdn/gdl/rest"
 	"github.com/rxdn/gdl/rest/request"
-	"net/http"
-	"strconv"
-	"strings"
-	"time"
 )
 
 func CallbackHandler(c *gin.Context) {
@@ -98,9 +99,10 @@ func CallbackHandler(c *gin.Context) {
 			"avatar":   currentUser.Avatar,
 			"admin":    utils.Contains(config.Conf.Admins, currentUser.Id),
 		},
+		"guilds": guilds,
 	}
-	if len(guilds) > 0 {
-		resMap["guilds"] = guilds
+	if guilds == nil {
+		resMap["guilds"] = []utils.GuildDto{}
 	}
 
 	c.JSON(http.StatusOK, resMap)

--- a/app/http/endpoints/root/callback.go
+++ b/app/http/endpoints/root/callback.go
@@ -62,7 +62,7 @@ func CallbackHandler(c *gin.Context) {
 		HasGuilds:    false,
 	}
 
-	var guilds []utils.GuildDto
+	guilds := make([]utils.GuildDto, 0)
 	if utils.Contains(scopes, "guilds") {
 		guilds, err = utils.LoadGuilds(c, res.AccessToken, currentUser.Id)
 		if err != nil {
@@ -100,9 +100,6 @@ func CallbackHandler(c *gin.Context) {
 			"admin":    utils.Contains(config.Conf.Admins, currentUser.Id),
 		},
 		"guilds": guilds,
-	}
-	if guilds == nil {
-		resMap["guilds"] = []utils.GuildDto{}
 	}
 
 	c.JSON(http.StatusOK, resMap)

--- a/frontend/src/views/LoginCallback.svelte
+++ b/frontend/src/views/LoginCallback.svelte
@@ -26,6 +26,8 @@
         window.localStorage.setItem('user_data', JSON.stringify(res.data.user_data));
         if (res.data.guilds) {
             window.localStorage.setItem('guilds', JSON.stringify(res.data.guilds));
+        } else {
+            window.localStorage.setItem('guilds', JSON.stringify([]));
         }
 
         let path = '/';


### PR DESCRIPTION
This PR fixes a bug related with users who do not have the bot in their personal servers. *This is mostly a fix for self-hosted instances of the bot.*

## Cause
The bug is caused by the api by returning an object without the `guilds` property.

## Fix
Initialize guilds in localStorage as an empty array (`[]`) if none are returned